### PR TITLE
Firmware cache and serve

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,7 +130,7 @@ RUN set -ex \
   && chmod -R 775 $app_firmware_dir
 
 # Clone Unit
-RUN set -ex && git clone --depth 1 -b 1.32.0-1 https://github.com/nginx/unit $unit_clone_dir
+RUN set -ex && git clone --depth 1 -b 1.32.1-1 https://github.com/nginx/unit $unit_clone_dir
 
 WORKDIR $unit_clone_dir
 

--- a/Dockerfile.minsize
+++ b/Dockerfile.minsize
@@ -142,7 +142,7 @@ RUN --mount=type=secret,id=vzw_secrets.h set -x \
   && chown root:$app_group $app_firmware_dir \
   && chmod -R 775 $app_firmware_dir \
 # Clone NGINX Unit
-  && git clone --depth 1 -b 1.32.0-1 https://github.com/nginx/unit $unit_clone_dir \
+  && git clone --depth 1 -b 1.32.1-1 https://github.com/nginx/unit $unit_clone_dir \
 # Configure and make unitd
   && cd $unit_clone_dir \
   && ./configure $unit_config_args --cc-opt="$(eval $cc_opt)" --ld-opt="$(eval $ld_opt)" \

--- a/src/curl_callbacks.c
+++ b/src/curl_callbacks.c
@@ -1,7 +1,6 @@
 /** @headerfile curl_callbacks.h */
 #include "curl_callbacks.h"
 
-#include <config.h>
 #include <string.h>
 
 size_t mem_write_callback(
@@ -11,7 +10,7 @@ size_t mem_write_callback(
   size_t realsize = size * nitems;
   RecvData *mem = (RecvData *)userdata;
 
-  memcpy(&(mem->response[mem->size]), buffer, realsize);
+  (void)memcpy(&(mem->response[mem->size]), buffer, realsize);
   mem->size += realsize;
   mem->response[mem->size] = 0;
   return realsize;

--- a/src/curl_callbacks.h
+++ b/src/curl_callbacks.h
@@ -4,10 +4,6 @@
 #ifndef CURL_CALLBACKS_H
 #define CURL_CALLBACKS_H
 #include <curl/curl.h>
-#include <stdlib.h>
-#include <string.h>
-
-#include "config.h"
 
 typedef struct RecvData {
   char *response;
@@ -22,31 +18,4 @@ size_t mem_write_callback(
     const char *buffer, const size_t size, const size_t nitems,
     const void *userdata
 );
-
-// typedef struct RecvData {
-//   char *memory;
-//   size_t size;
-// } RecvData;
-
-// static const size_t mem_cb(
-//     const void *contents, const size_t size, const size_t nmemb,
-//     const void *userp
-// ) {
-//   size_t realsize = size * nmemb;
-//   struct RecvData *mem = (struct RecvData *)userp;
-
-//   char *ptr = realloc(mem->memory, mem->size + realsize + 1);
-//   if (!ptr) {
-//     /* out of memory! */
-//     printf("not enough memory (realloc returned NULL)\n");
-//     return 0;
-//   }
-
-//   mem->memory = ptr;
-//   memcpy(&(mem->memory[mem->size]), contents, realsize);
-//   mem->size += realsize;
-//   mem->memory[mem->size] = 0;
-
-//   return realsize;
-// }
 #endif

--- a/src/firmware_requests.c
+++ b/src/firmware_requests.c
@@ -4,16 +4,18 @@
 #include <config.h>
 #include <curl/curl.h>
 #include <curl/header.h>
+#include <fcntl.h>
+#include <nxt_unit.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "curl_callbacks.h"
 
-#define REC_BUF_SIZE 2048
 #define REC_HEADER_SIZE 5000
 
 #define REPO "umts/embedded-departure-board"
 
-static void latest_version(char *headers, char *tag) {
+static void parse_tag(char *headers, char *tag) {
   char *p;
   p = strstr(headers, "location:");
   p += 9;
@@ -25,46 +27,98 @@ static void latest_version(char *headers, char *tag) {
   *(tag + tag_size) = '\0';
 }
 
-int latest_firmware(char *latest_tag) {
-  CURL *curl = curl_easy_init();
+static CURLcode latest_firmware_tag(
+    CURL *curl, char *header_buf, char *latest_tag
+) {
   CURLcode res;
 
-  char header_buf[REC_HEADER_SIZE];
-
-  char agent[19] = "licurl/";
-
-  RecvData header_data = {header_buf, 0};
-
-  curl_easy_setopt(curl, CURLOPT_DEFAULT_PROTOCOL, "https");
-  curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
-  curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
-  curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
-  curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
   curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
-
-  curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, mem_write_callback);
-  curl_easy_setopt(curl, CURLOPT_HEADERDATA, &header_data);
-
   curl_easy_setopt(
       curl, CURLOPT_URL, "https://github.com/" REPO "/releases/latest"
-  );
-  curl_easy_setopt(
-      curl, CURLOPT_USERAGENT,
-      strcat(agent, curl_version_info(CURLVERSION_NOW)->version)
   );
 
   res = curl_easy_perform(curl);
   if (res != CURLE_OK) {
     PRINTERR("curl_easy_perform() failed: %s", curl_easy_strerror(res));
-    goto fail;
+    goto cleanup;
   }
 
-fail:
-  curl_easy_cleanup(curl);
+  parse_tag(header_buf, latest_tag);
+  PRINTDBG("Latest firmware tag: %s", latest_tag);
 
-  latest_version(header_buf, latest_tag);
-  PRINTDBG("\n%s\n", latest_tag);
+cleanup:
+  return res;
+}
+
+int download_firmware_github(FILE **fptr, long *file_size) {
+  CURL *curl = curl_easy_init();
+  CURLcode res;
+  char *p;
+  char latest_tag[12];
+  char header_buf[REC_HEADER_SIZE];
+  char user_agent[19] = "licurl/";
+
+  RecvData header_data = {header_buf, 0};
+  curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, mem_write_callback);
+  curl_easy_setopt(curl, CURLOPT_HEADERDATA, &header_data);
+  curl_easy_setopt(curl, CURLOPT_DEFAULT_PROTOCOL, "https");
+  curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
+  curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+  curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+  curl_easy_setopt(
+      curl, CURLOPT_USERAGENT,
+      strcat(user_agent, curl_version_info(CURLVERSION_NOW)->version)
+  );
+  curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+
+  PRINTDBG("Getting latest firmware tag...");
+  res = latest_firmware_tag(curl, header_buf, latest_tag);
+  char filename[14 + strlen(latest_tag) + 16];
+  if (res != CURLE_OK) {
+    goto cleanup;
+  }
+
+  p = stpcpy(filename, "/srv/firmware/");
+  p = stpcpy(p, latest_tag);
+  (void)stpcpy(p, "_app_update.bin");
+
+  *fptr = fopen(filename, "wb+");
+  if (fptr == NULL) {
+    PRINTERR("Failed to create firmware file");
+    goto cleanup;
+  }
+
+  char url[80] = "https://github.com/" REPO "/releases/download/";
+
+  p = stpcpy((url + strlen(url)), &latest_tag[0]);
+  (void)stpcpy(p, "/app_update.bin");
+
+  header_data.size = 0;
+  curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, mem_write_callback);
+  curl_easy_setopt(curl, CURLOPT_HEADERDATA, &header_data);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, NULL);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, *fptr);
+  curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+  curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+  curl_easy_setopt(curl, CURLOPT_URL, url);
+
+  res = curl_easy_perform(curl);
+  if (res != CURLE_OK) {
+    PRINTERR("curl_easy_perform() failed: %s", curl_easy_strerror(res));
+    fclose(*fptr);
+  }
+
+  *file_size = ftell(*fptr);
+
+  // rewind(*fptr);
+  // if (fstat(fileno(*fptr), file_info) != 0) {
+  //   PRINTERR("Failed to stat firmware file");
+  // }
+  PRINTDBG("Firmware file size: %ld B", *file_size);
+
+cleanup:
+  curl_easy_cleanup(curl);
 
   return (int)res;
 }

--- a/src/firmware_requests.c
+++ b/src/firmware_requests.c
@@ -3,9 +3,6 @@
 
 #include <config.h>
 #include <curl/curl.h>
-#include <curl/header.h>
-#include <fcntl.h>
-#include <nxt_unit.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/src/firmware_requests.c
+++ b/src/firmware_requests.c
@@ -38,6 +38,7 @@ static CURLcode latest_firmware_tag(
       curl, CURLOPT_URL, "https://github.com/" REPO "/releases/latest"
   );
 
+  PRINTDBG("Fetching latest firmware tag...");
   res = curl_easy_perform(curl);
   if (res != CURLE_OK) {
     PRINTERR("curl_easy_perform() failed: %s", curl_easy_strerror(res));
@@ -72,7 +73,6 @@ int download_firmware_github(FILE **fptr, long *file_size) {
   );
   curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
-  PRINTDBG("Getting latest firmware tag...");
   res = latest_firmware_tag(curl, header_buf, latest_tag);
   char filename[14 + strlen(latest_tag) + 16];
   if (res != CURLE_OK) {
@@ -101,7 +101,10 @@ int download_firmware_github(FILE **fptr, long *file_size) {
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, *fptr);
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+  curl_easy_setopt(curl, CURLOPT_FORBID_REUSE, 1L);
   curl_easy_setopt(curl, CURLOPT_URL, url);
+
+  PRINTDBG("Downloading firmware file from %s to %s...", url, filename);
 
   res = curl_easy_perform(curl);
   if (res != CURLE_OK) {
@@ -110,15 +113,9 @@ int download_firmware_github(FILE **fptr, long *file_size) {
   }
 
   *file_size = ftell(*fptr);
-
-  // rewind(*fptr);
-  // if (fstat(fileno(*fptr), file_info) != 0) {
-  //   PRINTERR("Failed to stat firmware file");
-  // }
-  PRINTDBG("Firmware file size: %ld B", *file_size);
+  PRINTDBG("Done");
 
 cleanup:
   curl_easy_cleanup(curl);
-
   return (int)res;
 }

--- a/src/firmware_requests.h
+++ b/src/firmware_requests.h
@@ -6,7 +6,6 @@
 #define FIRMWARE_REQUESTS_H
 
 #include <stdio.h>
-#include <sys/stat.h>
 
 /** @fn int latest_firmware(char *tags_buf)
  *  @brief Gets a list of github release tags using the github-api.

--- a/src/firmware_requests.h
+++ b/src/firmware_requests.h
@@ -5,13 +5,16 @@
 #ifndef FIRMWARE_REQUESTS_H
 #define FIRMWARE_REQUESTS_H
 
-/** @fn int firmware_versions(void)
+#include <stdio.h>
+#include <sys/stat.h>
+
+/** @fn int latest_firmware(char *tags_buf)
  *  @brief Gets a list of github release tags using the github-api.
  */
-int latest_firmware(char *tags_buf);
+// int latest_firmware_tag(char *tags_buf);
 
-/** @fn firmware_update()
+/** @fn int update_firmware_github(char *tag, char *buf);
  *  @brief Proxys a firmware download octect-stream from github objects.
  */
-// int firmware_update();
+int download_firmware_github(FILE **fptr, long *file_size);
 #endif

--- a/src/firmware_requests.h
+++ b/src/firmware_requests.h
@@ -7,13 +7,8 @@
 
 #include <stdio.h>
 
-/** @fn int latest_firmware(char *tags_buf)
- *  @brief Gets a list of github release tags using the github-api.
+/** @fn int download_firmware_github(FILE **fptr);
+ *  @brief Caches and sends latest firmware from github releases.
  */
-// int latest_firmware_tag(char *tags_buf);
-
-/** @fn int update_firmware_github(char *tag, char *buf);
- *  @brief Proxys a firmware download octect-stream from github objects.
- */
-int download_firmware_github(FILE **fptr, long *file_size);
+int download_firmware_github(FILE **fptr);
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -101,9 +101,8 @@ int main(int argc, char **argv) {
     nxt_unit_free(ctx, threads);
   }
 
-  nxt_unit_done(ctx);
   curl_global_cleanup();
-
+  nxt_unit_done(ctx);
   nxt_unit_debug(NULL, "main worker done");
 
   return 0;

--- a/src/request_handler.c
+++ b/src/request_handler.c
@@ -7,12 +7,15 @@
 #define JSMN_HEADER
 
 #include <config.h>
+#include <curl/curl.h>
+#include <fcntl.h>
 #include <jsmn.h>
 #include <nxt_clang.h>
 #include <nxt_unit.h>
 #include <nxt_unit_sptr.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <time.h>
 
 #include "../config/vzw_secrets.h"
@@ -24,6 +27,7 @@
 #define TEXT_HTML_UTF8 "text/html; charset=utf-8"
 #define TEXT_PLAIN_UTF8 "text/plain; charset=utf-8"
 #define JSON_UTF8 "application/json; charset=utf-8"
+#define OCTET_STREAM "application/octet-stream;"
 
 static inline char *copy(char *p, const void *src, uint32_t len) {
   memcpy(p, src, len);
@@ -58,9 +62,7 @@ static int response_init(
       req_info, status, 1, nxt_length(CONTENT_TYPE) + strlen(type)
   );
   if (nxt_slow_path(rc != NXT_UNIT_OK)) {
-    nxt_unit_req_log(
-        req_info, NXT_UNIT_LOG_ALERT, "nxt_unit_response_init failed"
-    );
+    nxt_unit_req_error(req_info, "Failed to initialize response");
     return 1;
   }
 
@@ -68,15 +70,13 @@ static int response_init(
       req_info, CONTENT_TYPE, nxt_length(CONTENT_TYPE), type, strlen(type)
   );
   if (nxt_slow_path(rc != NXT_UNIT_OK)) {
-    nxt_unit_req_log(
-        req_info, NXT_UNIT_LOG_ALERT, "nxt_unit_response_add_field failed"
-    );
+    nxt_unit_req_error(req_info, "Failed to add field to response");
     return 1;
   }
 
   rc = nxt_unit_response_send(req_info);
   if (nxt_slow_path(rc != NXT_UNIT_OK)) {
-    nxt_unit_req_alert(req_info, "first nxt_unit_response_send failed");
+    nxt_unit_req_error(req_info, "Failed to send response headers");
     return 1;
   }
 
@@ -85,7 +85,6 @@ static int response_init(
 
 void vzw_request_handler(nxt_unit_request_info_t *req_info, int rc) {
   char *p;
-  // ssize_t res;
   nxt_unit_buf_t *buf;
 
   char vzw_auth_token[50] = "\0";
@@ -106,7 +105,6 @@ void vzw_request_handler(nxt_unit_request_info_t *req_info, int rc) {
       req_info, ((req_info->request_buf->end - req_info->request_buf->start) +
                  strlen("Hello world!\n"))
   );
-
   if (nxt_slow_path(buf == NULL)) {
     rc = NXT_UNIT_ERROR;
     nxt_unit_req_error(req_info, "Failed to allocate response buffer");
@@ -129,47 +127,88 @@ fail:
   nxt_unit_request_done(req_info, rc);
 }
 
-void firmware_versions_request_handler(
-    nxt_unit_request_info_t *req_info, int rc
-) {
+void firmware_request_handler(nxt_unit_request_info_t *req_info, int rc) {
   char *p;
-  char latest_tag[12];
   nxt_unit_buf_t *buf;
+  // struct stat file_info;
+  long file_size;
+  FILE *fptr;
 
-  rc = response_init(req_info, rc, 200, TEXT_PLAIN_UTF8);
+  rc = response_init(req_info, rc, 200, OCTET_STREAM);
   if (rc == 1) {
     goto fail;
   }
 
-  rc = latest_firmware(&latest_tag[0]);
+  rc = download_firmware_github(&fptr, &file_size);
   if (nxt_slow_path(rc != NXT_UNIT_OK)) {
-    nxt_unit_req_error(req_info, "Failed to get latest firmware version tag");
+    nxt_unit_req_error(req_info, "Failed to get latest firmware from GitHub");
     goto fail;
   }
-
-  buf = nxt_unit_response_buf_alloc(
-      req_info, ((req_info->request_buf->end - req_info->request_buf->start) +
-                 strlen(&latest_tag[0]))
-  );
-
-  if (nxt_slow_path(buf == NULL)) {
-    rc = NXT_UNIT_ERROR;
-    nxt_unit_req_error(req_info, "Failed to allocate response buffer");
-    goto fail;
+  // PRINTDBG("Sending firmware...");
+  // PRINTDBG("I/O block size: %ld B", file_info.st_blksize);
+  // PRINTDBG("Blocks allocated: %ld B", file_info.st_blocks);
+  rewind(fptr);
+  if (fptr == NULL) {
+    PRINTERR("fptr null");
   }
 
-  p = buf->free;
+  PRINTDBG("Firmware file size: %ld B", file_size);
 
-  p = copy(p, latest_tag, strlen(latest_tag));
+  // buf = nxt_unit_response_buf_alloc(
+  //     req_info,
+  //     ((req_info->request_buf->end - req_info->request_buf->start) +
+  //     file_size)
+  // );
+  // if (nxt_slow_path(buf == NULL)) {
+  //   rc = NXT_UNIT_ERROR;
+  //   nxt_unit_req_error(req_info, "Failed to allocate response buffer");
+  //   goto fail;
+  // }
+  // p = buf->free;
 
-  buf->free = p;
-  rc = nxt_unit_buf_send(buf);
-  if (nxt_slow_path(rc != NXT_UNIT_OK)) {
-    nxt_unit_req_error(req_info, "Failed to send buffer");
-    goto fail;
-  }
+  // rc = fread(p, file_size, 1, fptr);
+  // if (rc != 1) {
+  //   nxt_unit_req_error(req_info, "fread returned %d", rc);
+  //   // goto fail;
+  // }
+
+  // int i = 0;
+  // while (!feof(fptr)) {
+  // buf = nxt_unit_response_buf_alloc(
+  //     req_info, ((req_info->request_buf->end - req_info->request_buf->start)
+  //     +
+  //                file_info.st_blksize)
+  // );
+  // if (nxt_slow_path(buf == NULL)) {
+  //   rc = NXT_UNIT_ERROR;
+  //   nxt_unit_req_error(req_info, "Failed to allocate response buffer");
+  //   goto fail;
+  // }
+  // PRINTDBG("\rAllocated send buffer %d", i);
+  // p = buf->free;
+
+  // if (fread(p, file_info.st_blksize, 1, fptr) != 1) {
+  //   nxt_unit_req_error(req_info, "Failed to read firmware file");
+  //   goto fail;
+  // }
+
+  nxt_unit_response_write(req_info, fptr, file_size);
+
+  // buf->free = p;
+  // rc = nxt_unit_buf_send(buf);
+  // if (nxt_slow_path(rc != NXT_UNIT_OK)) {
+  //   nxt_unit_req_error(req_info, "Failed to send buffer");
+  // goto fail;
+  // }
+  //   i++;
+  // }
+  // p = copy(p, "Hello world!", strlen("Hello world!"));
+
+  // PRINTDBG("Firmware file size: %ld B", file_info.st_size);
+  // nxt_unit_response_write(req_info, fptr, (file_info.st_size * 8));
 
 fail:
+  fclose(fptr);
   nxt_unit_request_done(req_info, rc);
 }
 
@@ -182,13 +221,13 @@ void request_router(nxt_unit_request_info_t *req_info) {
   if (strncmp(path, "/vzw", 4) == 0) {
     (void)vzw_request_handler(req_info, rc);
   } else if ((strncmp(path, "/firmware", 9) == 0)) {
-    (void)firmware_versions_request_handler(req_info, rc);
+    (void)firmware_request_handler(req_info, rc);
   } else {
     response_init(req_info, rc, 404, TEXT_PLAIN_UTF8);
     if (rc == 1) {
       goto fail;
     }
-    nxt_unit_response_write(req_info, "Error 404", strlen("Error 404"));
+    nxt_unit_response_write(req_info, "Error 404", sizeof("Error 404") - 1);
   }
 
 fail:

--- a/src/request_handler.c
+++ b/src/request_handler.c
@@ -7,20 +7,15 @@
 #define JSMN_HEADER
 
 #include <config.h>
-#include <curl/curl.h>
-#include <fcntl.h>
-#include <jsmn.h>
 #include <nxt_clang.h>
 #include <nxt_unit.h>
 #include <nxt_unit_sptr.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <time.h>
 
 #include "../config/vzw_secrets.h"
 #include "firmware_requests.h"
-#include "json_helpers.h"
 #include "vzw_connect.h"
 
 #define CONTENT_TYPE "Content-Type"

--- a/src/request_handler.c
+++ b/src/request_handler.c
@@ -130,9 +130,10 @@ fail:
 void firmware_request_handler(nxt_unit_request_info_t *req_info, int rc) {
   char *p;
   nxt_unit_buf_t *buf;
-  // struct stat file_info;
+  struct stat file_info;
   long file_size;
   FILE *fptr;
+  size_t io_blocks;
 
   rc = response_init(req_info, rc, 200, OCTET_STREAM);
   if (rc == 1) {
@@ -144,71 +145,72 @@ void firmware_request_handler(nxt_unit_request_info_t *req_info, int rc) {
     nxt_unit_req_error(req_info, "Failed to get latest firmware from GitHub");
     goto fail;
   }
-  // PRINTDBG("Sending firmware...");
-  // PRINTDBG("I/O block size: %ld B", file_info.st_blksize);
-  // PRINTDBG("Blocks allocated: %ld B", file_info.st_blocks);
-  rewind(fptr);
+
+  (void)rewind(fptr);
   if (fptr == NULL) {
     PRINTERR("fptr null");
   }
 
+  if (fstat(fileno(fptr), &file_info) != 0) {
+    perror("[firmware_request_handler] Failed to stat firmware file. Error");
+  }
+
+  /* file_info.st_blocks is the number of 512B blocks allocated on Linux.
+   * file_info.st_blksize is the preferred blocksize for file system I/O, likey
+   * larger that 512B.
+   */
+  if (file_info.st_blksize > 512) {
+    io_blocks = file_info.st_blocks / (file_info.st_blksize / 512);
+  } else if (file_info.st_blksize < 512) {
+    io_blocks = file_info.st_blocks * (512 / file_info.st_blksize);
+  } else {
+    io_blocks = file_info.st_blocks;
+  }
+
   PRINTDBG("Firmware file size: %ld B", file_size);
+  PRINTDBG("I/O block size: %ld B", file_info.st_blksize);
+  PRINTDBG("Blocks allocated: %ld", io_blocks);
 
-  // buf = nxt_unit_response_buf_alloc(
-  //     req_info,
-  //     ((req_info->request_buf->end - req_info->request_buf->start) +
-  //     file_size)
-  // );
-  // if (nxt_slow_path(buf == NULL)) {
-  //   rc = NXT_UNIT_ERROR;
-  //   nxt_unit_req_error(req_info, "Failed to allocate response buffer");
-  //   goto fail;
-  // }
-  // p = buf->free;
+  PRINTDBG("Sending firmware...");
+  for (size_t i = 0; i < io_blocks; i++) {
+    buf = nxt_unit_response_buf_alloc(req_info, (file_info.st_blksize));
+    if (nxt_slow_path(buf == NULL)) {
+      rc = NXT_UNIT_ERROR;
+      PRINTERR("Failed to allocate response buffer");
+      goto fail;
+    }
+    p = buf->free;
 
-  // rc = fread(p, file_size, 1, fptr);
-  // if (rc != 1) {
-  //   nxt_unit_req_error(req_info, "fread returned %d", rc);
-  //   // goto fail;
-  // }
+    if (fread(p, file_info.st_blksize, 1, fptr) == 1) {
+      buf->free = (p + file_info.st_blksize);
+    } else if (ferror(fptr)) {
+      perror("Failed to read firmware file. Error");
+      goto fail;
+    } else {
+      /* Reached EOF, we're on the last buffer. The remaining file data is
+       * smaller than the allocated memory and we don't want to send extra data.
+       * To get the actual size of data in this buffer we have to do some math:
+       * The size of total bytes alocated - actual file size bytes gives us the
+       * size of unused memory in bytes. We subtract that from the size of the
+       * current buffer, file_info.st_blksize.
+       */
+      buf->free =
+          (p +
+           (file_info.st_blksize - ((file_info.st_blocks * 512) - file_size)));
+    }
 
-  // int i = 0;
-  // while (!feof(fptr)) {
-  // buf = nxt_unit_response_buf_alloc(
-  //     req_info, ((req_info->request_buf->end - req_info->request_buf->start)
-  //     +
-  //                file_info.st_blksize)
-  // );
-  // if (nxt_slow_path(buf == NULL)) {
-  //   rc = NXT_UNIT_ERROR;
-  //   nxt_unit_req_error(req_info, "Failed to allocate response buffer");
-  //   goto fail;
-  // }
-  // PRINTDBG("\rAllocated send buffer %d", i);
-  // p = buf->free;
-
-  // if (fread(p, file_info.st_blksize, 1, fptr) != 1) {
-  //   nxt_unit_req_error(req_info, "Failed to read firmware file");
-  //   goto fail;
-  // }
-
-  nxt_unit_response_write(req_info, fptr, file_size);
-
-  // buf->free = p;
-  // rc = nxt_unit_buf_send(buf);
-  // if (nxt_slow_path(rc != NXT_UNIT_OK)) {
-  //   nxt_unit_req_error(req_info, "Failed to send buffer");
-  // goto fail;
-  // }
-  //   i++;
-  // }
-  // p = copy(p, "Hello world!", strlen("Hello world!"));
-
-  // PRINTDBG("Firmware file size: %ld B", file_info.st_size);
-  // nxt_unit_response_write(req_info, fptr, (file_info.st_size * 8));
+    rc = nxt_unit_buf_send(buf);
+    if (nxt_slow_path(rc != NXT_UNIT_OK)) {
+      PRINTERR("Failed to send buffer");
+      goto fail;
+    }
+  }
+  PRINTDBG("Done");
 
 fail:
-  fclose(fptr);
+  if (fclose(fptr)) {
+    perror("Failed to close firmware file. Error");
+  }
   nxt_unit_request_done(req_info, rc);
 }
 


### PR DESCRIPTION
Download the latest firmware from Github releases to cache and serve.

Does not currently use the Github API, just plain HTTP directed at the browser. It uses https://github.com/umts/embedded-departure-board/releases/latest to get the latest tag and then
https://github.com/umts/embedded-departure-board/releases/download/vX.X.X/app_update.bin to download the firmware.